### PR TITLE
Integrate apollo inspector to devtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .npmrc
 playground/public/apollo-devtools.js
 playground/public/apollo-devtools.js.map
+dist/*

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@apollo/client": "3.6.5",
+    "@apollo/client": "3.6.6",
     "@fluentui/react-components": "^9.0.0-rc.9",
     "@fluentui/react-tabster": "^9.0.0-rc.7",
     "@types/jest": "^27.4.1",
@@ -49,5 +49,8 @@
     "typescript": "^4.6.3",
     "uuid": "^8.3.2",
     "watch": "^1.0.2"
+  },
+  "dependencies": {
+    "apollo-inspector": "^1.4.0"
   }
 }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -8,6 +8,7 @@ import {
   DataFunnel24Regular,
   DataWhisker24Regular,
   Alert24Regular,
+  ArrowHookDownRight24Filled,
 } from "@fluentui/react-icons";
 import { mergeClasses, Text, Badge } from "@fluentui/react-components";
 import { useArrowNavigationGroup } from "@fluentui/react-tabster";
@@ -46,6 +47,11 @@ const menuElements = (props: MenuProps) => [
     url: "activity",
     name: "Activity monitor",
     icon: <Alert24Regular />,
+  },
+  {
+    url: "operations-tracker",
+    name: "Operations tracker",
+    icon: <ArrowHookDownRight24Filled />,
   },
   {
     url: "apollo-additional-informations",

--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -6,6 +6,8 @@ import { ApolloTrackerPublisher } from "./publishers/apollo-tracker-publisher";
 import { ApolloClientsPublisher } from "./publishers/apollo-clients-publisher";
 import { ApolloGlobalOperationsPublisher } from "./publishers/apollo-global-operations-publisher";
 import { ApolloRecentActivityPublisher } from "./publishers/apollo-recent-activity-publisher";
+import { ApolloOperationsTrackerPublisher } from "./publishers/apollo-operations-tracker-publisher";
+import { ApolloOperationsTrackerTMPPublisher } from "./publishers/apollo-operations-tracker-tmp-publisher";
 
 const remplWrapper = new RemplWrapper(
   "ctrl+shift+alt+0, command+shift+option+0",
@@ -18,3 +20,5 @@ new ApolloGlobalOperationsPublisher(remplWrapper);
 new GraphiQLPublisher(remplWrapper);
 new ApolloCacheDuplicatesPublisher(remplWrapper);
 new ApolloRecentActivityPublisher(remplWrapper);
+// new ApolloOperationsTrackerPublisher(remplWrapper);
+new ApolloOperationsTrackerTMPPublisher(remplWrapper);

--- a/src/publisher/publishers/apollo-operations-tracker-publisher.ts
+++ b/src/publisher/publishers/apollo-operations-tracker-publisher.ts
@@ -1,0 +1,64 @@
+import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import { RemplWrapper } from "../rempl-wrapper";
+import {
+  ApolloInspector,
+  IStopTracking,
+  IInspectorTrackingConfig,
+  IDataView,
+} from "apollo-inspector";
+import { WrapperCallbackParams } from "../../types";
+
+export class ApolloOperationsTrackerPublisher {
+  private remplWrapper: RemplWrapper;
+  protected apolloPublisher;
+  protected stopTracking: IStopTracking | undefined;
+  protected activeClient: ApolloClient<NormalizedCacheObject> | undefined;
+  protected isRecording: boolean;
+
+  constructor(remplWrapper: RemplWrapper) {
+    this.remplWrapper = remplWrapper;
+    this.isRecording = false;
+    this.remplWrapper.subscribeToRemplStatus(
+      "operations-tracker",
+      this.setActiveClient.bind(this),
+      400,
+    );
+    this.apolloPublisher = remplWrapper.publisher;
+    this.attachMethodsToPublisher();
+  }
+
+  protected attachMethodsToPublisher() {
+    this.apolloPublisher.provide(
+      "startOperationsTracker",
+      (options: IInspectorTrackingConfig | undefined) => {
+        if (this.activeClient) {
+          this.isRecording = true;
+          const inspector = new ApolloInspector(this.activeClient);
+          if (options && Object.keys(options).length === 0) {
+            options = undefined;
+          }
+          this.stopTracking = inspector.startTracking(
+            options as unknown as IInspectorTrackingConfig,
+          );
+        }
+      },
+    );
+
+    this.apolloPublisher.provide("stopOperationsTracker", () => {
+      if (this.stopTracking) {
+        this.isRecording = false;
+        const data = this.stopTracking?.();
+        this.publishApolloOperations(data);
+        this.stopTracking = undefined;
+      }
+    });
+  }
+
+  protected publishApolloOperations(data: IDataView) {
+    this.apolloPublisher.ns("apollo-operations-tracker").publish(data);
+  }
+
+  private setActiveClient({ activeClient }: WrapperCallbackParams) {
+    this.activeClient = activeClient?.client;
+  }
+}

--- a/src/publisher/publishers/apollo-operations-tracker-tmp-publisher.ts
+++ b/src/publisher/publishers/apollo-operations-tracker-tmp-publisher.ts
@@ -1,0 +1,274 @@
+import { ApolloLink, Observable, FetchResult } from "@apollo/client";
+import { RemplWrapper } from "../rempl-wrapper";
+import {
+  ApolloInspector,
+  IInspectorTrackingConfig,
+  IHook,
+  IVerboseOperation,
+} from "apollo-inspector";
+import { ApolloOperationsTrackerPublisher } from "./apollo-operations-tracker-publisher";
+
+export class ApolloOperationsTrackerTMPPublisher extends ApolloOperationsTrackerPublisher {
+  constructor(remplWrapper: RemplWrapper) {
+    super(remplWrapper);
+  }
+
+  protected attachMethodsToPublisher() {
+    this.apolloPublisher.provide(
+      "startOperationsTracker",
+      (options: IInspectorTrackingConfig | undefined) => {
+        if (this.activeClient) {
+          this.isRecording = true;
+          const inspector = new ApolloInspector(this.activeClient);
+          if (options && Object.keys(options).length === 0) {
+            options = undefined;
+          }
+          options = this.addCDLInspectorHook(options);
+          this.stopTracking = inspector.startTracking(
+            options as unknown as IInspectorTrackingConfig,
+          );
+        }
+      },
+    );
+
+    this.apolloPublisher.provide("stopOperationsTracker", () => {
+      if (this.stopTracking) {
+        this.isRecording = false;
+        const data = this.stopTracking?.();
+        this.publishApolloOperations(data);
+        this.stopTracking = undefined;
+      }
+    });
+  }
+
+  private addCDLInspectorHook(options: IInspectorTrackingConfig | undefined) {
+    if (options) {
+      if (options.hooks) {
+        options.hooks = [...options.hooks, new CDLInspectorHook()];
+        return options;
+      } else {
+        options.hooks = [new CDLInspectorHook()];
+        return options;
+      }
+    } else {
+      options = {
+        tracking: {
+          trackCacheOperation: false,
+          trackVerboseOperations: false,
+          trackAllOperations: true,
+        },
+        hooks: [new CDLInspectorHook()],
+      } as unknown as IInspectorTrackingConfig;
+      return options;
+    }
+  }
+}
+
+interface ITimeInfo {
+  windowToWorkerRequestSendTime?: DOMHighResTimeStamp;
+  windowToWorkerRequestReceviedTime?: DOMHighResTimeStamp;
+  workerToWindowRequestSendTime?: DOMHighResTimeStamp;
+  workerToWindowRequestReceiveTime?: DOMHighResTimeStamp;
+  workerResponseTime?: DOMHighResTimeStamp;
+}
+
+interface IResult {
+  extensions?: IExtensions;
+}
+interface IError {
+  extensions?: IExtensions;
+}
+
+export interface IExtensions {
+  perfStats: {
+    requestReceivedTime: number;
+    responseSendTime: number;
+    workerResponseTime: number;
+  };
+}
+
+class CDLInspectorHook implements IHook {
+  private operationsMap: Map<number, ITimeInfo>;
+  private decimalNumber = 2;
+
+  constructor() {
+    this.operationsMap = new Map();
+  }
+  public getLink(cb: () => number): ApolloLink {
+    const link = new ApolloLink((op, forward) => {
+      const windowToWorkerRequestSendTime = performance.now();
+      const operationId = cb();
+      this.operationsMap.set(operationId, { windowToWorkerRequestSendTime });
+      const obs: Observable<
+        FetchResult<
+          Record<string, any>,
+          Record<string, any>,
+          Record<string, any>
+        >
+      > = forward(op);
+      obs.subscribe({
+        next: (
+          result: FetchResult<
+            Record<string, any>,
+            Record<string, any>,
+            Record<string, any>
+          >,
+        ) => {
+          const typedResult = result as IResult;
+          const opId = cb();
+          if (opId !== 0 && typedResult.extensions?.perfStats) {
+            const timeInfo = this.getExitingTimeInfo(cb);
+            const perfStatsAddedTimeInfo = this.addPerfStatsToTimeInfo(
+              typedResult.extensions,
+              timeInfo,
+            );
+            this.operationsMap.set(opId, perfStatsAddedTimeInfo);
+          }
+        },
+        error: (error) => {
+          const typedError = error as IError;
+          const opId = cb();
+
+          if (opId !== 0 && typedError.extensions?.perfStats) {
+            const timeInfo = this.getExitingTimeInfo(cb);
+            const perfStatsAddedTimeInfo = this.addPerfStatsToTimeInfo(
+              typedError.extensions,
+              timeInfo,
+            );
+            this.operationsMap.set(opId, perfStatsAddedTimeInfo);
+          }
+        },
+      });
+
+      return obs;
+    });
+
+    return link;
+  }
+
+  public transform(op: IVerboseOperation) {
+    const operationId = op.id;
+    const windowToWorkerIpcTime: DOMHighResTimeStamp | string =
+      this.getWindowToWorkerIpcTime(operationId);
+    const workerToWindowIpcTime: DOMHighResTimeStamp | string =
+      this.getWorkerToWindowIpcTime(operationId);
+    const ipcTime: DOMHighResTimeStamp | string = this.getIpcTime(operationId);
+    const timeSpentInWorker: DOMHighResTimeStamp | string =
+      this.getTimeSpentInWorker(operationId);
+
+    op.duration = {
+      ...op.duration,
+      windowToWorkerIpcTime,
+      workerToWindowIpcTime,
+      ipcTime,
+      timeSpentInWorker,
+    } as any;
+    return op;
+  }
+
+  private getTimeSpentInWorker(operationId: number): string | number {
+    const timeInfo = this.operationsMap.get(operationId);
+    if (!timeInfo) {
+      return "NA";
+    }
+    if (timeInfo.workerResponseTime) {
+      const time = timeInfo.workerResponseTime;
+
+      if (!isNaN(time)) {
+        return parseFloat(time.toFixed(this.decimalNumber));
+      }
+    }
+
+    return "NA";
+  }
+
+  private getIpcTime(operationId: number): string | number {
+    const timeInfo = this.operationsMap.get(operationId);
+    if (!timeInfo) {
+      return "NA";
+    }
+    const {
+      windowToWorkerRequestSendTime,
+      workerToWindowRequestReceiveTime,
+      workerResponseTime,
+    } = timeInfo;
+    if (
+      windowToWorkerRequestSendTime &&
+      workerToWindowRequestReceiveTime &&
+      workerResponseTime
+    ) {
+      const time =
+        workerToWindowRequestReceiveTime -
+        windowToWorkerRequestSendTime -
+        workerResponseTime;
+
+      if (!isNaN(time)) {
+        return parseFloat(time.toFixed(this.decimalNumber));
+      }
+    }
+
+    return "NA";
+  }
+
+  private getWindowToWorkerIpcTime(operationId: number): string | number {
+    const timeInfo = this.operationsMap.get(operationId);
+    if (!timeInfo) {
+      return "NA";
+    }
+    if (
+      timeInfo.windowToWorkerRequestReceviedTime &&
+      timeInfo.windowToWorkerRequestSendTime
+    ) {
+      const time =
+        timeInfo.windowToWorkerRequestReceviedTime -
+        timeInfo.windowToWorkerRequestSendTime;
+
+      if (!isNaN(time)) {
+        return parseFloat(time.toFixed(this.decimalNumber));
+      }
+    }
+
+    return "NA";
+  }
+
+  private getWorkerToWindowIpcTime(operationId: number): string | number {
+    const timeInfo = this.operationsMap.get(operationId);
+    if (!timeInfo) {
+      return "NA";
+    }
+    if (
+      timeInfo.workerToWindowRequestReceiveTime &&
+      timeInfo.workerToWindowRequestSendTime
+    ) {
+      const time =
+        timeInfo.workerToWindowRequestReceiveTime -
+        timeInfo.workerToWindowRequestSendTime;
+
+      if (!isNaN(time)) {
+        return parseFloat(time.toFixed(this.decimalNumber));
+      }
+    }
+
+    return "NA";
+  }
+
+  private getExitingTimeInfo(cb: () => number) {
+    const operationId = cb();
+    const timeInfo = this.operationsMap.get(operationId);
+    if (!timeInfo) {
+      return {};
+    }
+    return timeInfo;
+  }
+  private addPerfStatsToTimeInfo(extensions: IExtensions, timeInfo: ITimeInfo) {
+    const { requestReceivedTime, responseSendTime, workerResponseTime } =
+      extensions.perfStats;
+
+    timeInfo.windowToWorkerRequestReceviedTime = requestReceivedTime;
+    timeInfo.workerToWindowRequestSendTime = responseSendTime;
+    timeInfo.workerToWindowRequestReceiveTime = performance.now();
+    timeInfo.workerResponseTime = workerResponseTime;
+
+    return timeInfo;
+  }
+}

--- a/src/subscriber/App.tsx
+++ b/src/subscriber/App.tsx
@@ -5,6 +5,7 @@ import { ApolloGlobalOperationsWrapper } from "./contexts/apollo-global-operatio
 import { ActiveClientContextWrapper } from "./contexts/active-client-context";
 import { ApolloCacheContextWrapper } from "./contexts/apollo-cache-context";
 import { ApolloCacheDuplicatesContextWrapper } from "./contexts/apollo-cache-duplicates-context";
+import { ApolloOperationTrackerContextWrapper } from "./contexts";
 import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
 
 const App = () => (
@@ -16,9 +17,11 @@ const App = () => (
       <ActiveClientContextWrapper>
         <ApolloClientMetadataWrapper>
           <ApolloCacheContextWrapper>
-            <ApolloCacheDuplicatesContextWrapper>
-              <Router />
-            </ApolloCacheDuplicatesContextWrapper>
+            <ApolloOperationTrackerContextWrapper>
+              <ApolloCacheDuplicatesContextWrapper>
+                <Router />
+              </ApolloCacheDuplicatesContextWrapper>
+            </ApolloOperationTrackerContextWrapper>
           </ApolloCacheContextWrapper>
         </ApolloClientMetadataWrapper>
       </ActiveClientContextWrapper>

--- a/src/subscriber/Router.tsx
+++ b/src/subscriber/Router.tsx
@@ -11,6 +11,7 @@ import {
 } from "./contexts/apollo-cache-context";
 import { Menu } from "../components";
 import RecentActivityContainer from "./apollo-recent-activity/recent-activity-container";
+import { OperationsTrackerContainer } from "./apollo-operations-tracker";
 import { ApolloGlobalOperationsContext } from "./contexts/apollo-global-operations-context";
 import { ApolloGlobalOperations } from "../types";
 
@@ -57,6 +58,9 @@ const Router = React.memo(() => {
           </Route>
           <Route path="/activity">
             <RecentActivityContainer />
+          </Route>
+          <Route path="/operations-tracker">
+            <OperationsTrackerContainer />
           </Route>
           <Route path="/graphiql">
             <GraphiQLRenderer />

--- a/src/subscriber/apollo-operations-tracker/index.ts
+++ b/src/subscriber/apollo-operations-tracker/index.ts
@@ -1,0 +1,1 @@
+export * from "./operations-tracker-container";

--- a/src/subscriber/apollo-operations-tracker/operations-tracker-container.tsx
+++ b/src/subscriber/apollo-operations-tracker/operations-tracker-container.tsx
@@ -1,0 +1,36 @@
+import { remplSubscriber } from "../rempl";
+import * as React from "react";
+import { ApolloOperationsTrackerContext } from "../contexts";
+import { Button } from "@fluentui/react-components";
+export const OperationsTrackerContainer = () => {
+  const { data, setApolloOperationsData } = React.useContext(
+    ApolloOperationsTrackerContext,
+  );
+  const [isRecording, setIsRecording] = React.useState<boolean>(false);
+
+  const toggleRecording = React.useCallback(() => {
+    setIsRecording?.((isRecording) => {
+      if (!isRecording) {
+        remplSubscriber.callRemote("startOperationsTracker");
+      } else {
+        remplSubscriber.callRemote("stopOperationsTracker", {});
+      }
+      return !isRecording;
+    });
+  }, [setIsRecording]);
+
+  React.useEffect(() => {
+    return () => {
+      remplSubscriber.callRemote("stopOperationsTracker", {});
+    };
+  }, [remplSubscriber]);
+
+  return (
+    <div>
+      able to render{" "}
+      <Button onClick={toggleRecording}>
+        {isRecording ? "Stop Recording" : "Start Recording"}
+      </Button>
+    </div>
+  );
+};

--- a/src/subscriber/contexts/apollo-operations-tracker-context.tsx
+++ b/src/subscriber/contexts/apollo-operations-tracker-context.tsx
@@ -1,0 +1,44 @@
+import { IDataView } from "apollo-inspector";
+import React, { useEffect, useState, createContext, useMemo } from "react";
+import { remplSubscriber } from "../rempl";
+import { ApolloOperationsTracker } from "../../types";
+
+export const defaultApolloOperationsTracker: ApolloOperationsTracker = {
+  data: undefined,
+  setApolloOperationsData: undefined,
+};
+
+export const ApolloOperationsTrackerContext =
+  createContext<ApolloOperationsTracker>(defaultApolloOperationsTracker);
+
+export const ApolloOperationTrackerContextWrapper = ({
+  children,
+}: {
+  children: JSX.Element;
+}) => {
+  const [apollOperationsData, setApolloOperationsData] =
+    useState<IDataView | null>(null);
+
+  useEffect(() => {
+    remplSubscriber
+      .ns("apollo-operations-tracker")
+      .subscribe((data: IDataView) => {
+        setApolloOperationsData(data);
+      });
+  }, []);
+
+  const providerValue = useMemo(
+    () =>
+      ({
+        data: apollOperationsData,
+        setApolloOperationsData,
+      } as ApolloOperationsTracker),
+    [apollOperationsData, setApolloOperationsData],
+  );
+
+  return (
+    <ApolloOperationsTrackerContext.Provider value={providerValue}>
+      {children}
+    </ApolloOperationsTrackerContext.Provider>
+  );
+};

--- a/src/subscriber/contexts/index.ts
+++ b/src/subscriber/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from "./apollo-operations-tracker-context";

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import {
   ApolloClient,
   StoreObject,
 } from "@apollo/client";
+import { IDataView } from "apollo-inspector";
 import { createPublisher } from "rempl";
 
 export type Publisher = ReturnType<typeof createPublisher>;
@@ -70,6 +71,13 @@ export type ApolloTrackerMetadata = {
   queriesCount: number;
   queriesHaveError: boolean;
   mutationsHaveError: boolean;
+};
+
+export type ApolloOperationsTracker = {
+  data: IDataView | undefined;
+  setApolloOperationsData:
+    | React.Dispatch<React.SetStateAction<IDataView | null>>
+    | undefined;
 };
 
 export type ClientRecentCacheObject = NormalizedCacheObject;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apollo/client@3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.5.tgz#6a7baaf05852187b0eac1c6064e721d47326d70c"
-  integrity sha512-xGAZzv1f5abyH45MSU5eOLyGQuP4Ps0OhP36pSCtt6pCICI3n4yDkdftFCPvqDVqVTuciX1kkyeJPfGodz5kwg==
+"@apollo/client@3.6.6":
+  version "3.6.6"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@apollo/client/-/client-3.6.6.tgz#3fb1f5b11da9a64b51b5a86b62450bee034e7f41"
+  integrity sha1-P7H1sR2ppktRtahrYkUL7gNOf0E=
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.6.0"
@@ -2500,6 +2500,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
   integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
 
+"@types/node@^18.11.17":
+  version "18.11.18"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
+  integrity sha1-jfuX8Nojwik+VUxaUNYe8TTXaX8=
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -3064,6 +3069,16 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+apollo-inspector@^1.4.0:
+  version "1.4.0"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/apollo-inspector/-/apollo-inspector-1.4.0.tgz#8076add3f7ce153b738e2b0d98b63e510f27910e"
+  integrity sha1-gHat0/fOFTtzjisNmLY+UQ8nkQ4=
+  dependencies:
+    "@apollo/client" "3.6.6"
+    "@types/node" "^18.11.17"
+    graphql "^16.6.0"
+    lodash "^4.17.21"
 
 arg@^5.0.1:
   version "5.0.1"
@@ -5464,6 +5479,11 @@ graphql@^15.0.0:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
+graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha1-wtz/pGSdsUn2KCr3JsjIPxx8X9s=
 
 gzip-size@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
### Integrate Apollo Inspector to Apollo devtools
As part of the integrations following changes has been done

## Created the Apollo-operations-tracker publisher
Created a new file named `apollo-operations-tracker-publisher.ts`. This file creates a new instance of apollo-inspector and starts the tracking. This file also publishes the result from the apollo-inspector.

Created a file name `apollo-operations-tracker-tmp-publisher.ts`. This file extends `apollo-operations-tracker-publisher.ts` and extra functionality to track operations. This file adds CDLInspector hook, which helps to track how much time the operations spent in IPC and worker. 

### Reasons for creating `apollo-operations-tracker-tmp-publisher.ts`
- Currently the devtool is being used in TMP, so created a publisher specific to TMP. When this devtool needs to be used by some other team, the simplest change needed would be to replace `ApolloOperationsTrackerTMPPublisher` with `ApolloOperationsTrackerPublisher`. 
- Apollo-inspector config allows providing an apollo-link, which will be added to the existing apollo-link chains. Using this, one can measure their own metric, other than what apollo-inspector measures.
- Added a CDLInspector apollo-link to measure the amount of time spent in IPC and in the worker. This helps dev to see complete breakdown of time for an operation. 


## Created the Apollo-operations-tracker-context
This context subscribes to apollo-operations-tracker publisher and reads the result from it.

## Created the Apollo-operations-tracker-container
This is the UI container where all the results will be rendered.

## Added a new entry point in the route
Added a new entry point in route to render the operations-tracker

## upgraded @apollo/client to 3.6.6
Apollo-inspector has dependency on @apollo/client to 3.6.6, so while using the types from @apollo/client to 3.6.5, typescript was complaining that both are different types, so had to upgrade the version.

